### PR TITLE
Support ESP_PLATFORM without Arduino.h

### DIFF
--- a/QDispatch.cpp
+++ b/QDispatch.cpp
@@ -276,7 +276,11 @@ TaskContext &TaskQueue::iterator::operator*() const
 //
 unsigned long TaskDispatcher::millis()
 {
-	return ::millis();
+#if defined(ESP_PLATFORM)
+  return esp_timer_get_time() / 1000;
+#else
+  return ::millis();
+#endif
 }
 
 TaskDispatcher::TaskDispatcher(unsigned long (*timingFunction)(), ContextPool *contextPool)

--- a/QDispatchCore.h
+++ b/QDispatchCore.h
@@ -29,7 +29,13 @@
 #ifndef QDispatchCore_h
 #define QDispatchCore_h
 
+#if defined(ESP_PLATFORM)
+#include <cstddef>
+#include <cstdint>
+#include <esp_timer.h>
+#else
 #include <Arduino.h>
+#endif
 
 namespace QDispatch {
 


### PR DESCRIPTION
Making this work with esp-idf, without Arduino.h

`#include <cstddef>` for `nullptr_t`
`#include <cstdint>` for integer types such as `int8_t`
`#include <esp_timer.h>` to get `esp_timer_get_time()`, which returns microseconds.

I am also working on a CMakeLists.txt and idf_component.yml so it can be directly used as a component on esp-idf, but i'll open a separate PR for that later.
